### PR TITLE
Fix electron-installer-redhat RPM spec copy path

### DIFF
--- a/patches/electron-installer-redhat+3.4.0.patch
+++ b/patches/electron-installer-redhat+3.4.0.patch
@@ -8,3 +8,8 @@ index e07a8a3..486f59e 100644
  
  %if "%{_host_cpu}" != "%{_target_cpu}"
  %global __strip /bin/true
+@@ -26,3 +27,3 @@
+ %>%install
+ mkdir -p %{buildroot}/usr/
+-cp <%= process.platform === 'darwin' ? '-R' : '-r' %> usr/* %{buildroot}/usr/
++cp <%= process.platform === 'darwin' ? '-R' : '-r' %> %{_topdir}/BUILD/usr/* %{buildroot}/usr/


### PR DESCRIPTION
Update the patch for electron-installer-redhat to copy from the actual staging build directory Prevents cp: cannot stat 'usr/*' on rpm 4.20+ during %install

I’m not sure whether this fix works well in other environments, but at least in my local testing on Fedora 43 with Node 24, it works fine.
I noticed that someone else has already submitted a fix to the upstream dependency repo here: https://github.com/electron-userland/electron-installer-redhat/pull/344, but it hasn’t been merged—there seems to be some reason for that.