### PR TITLE
CLI: support for a new "open in new window" flag

### DIFF
--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -46,6 +46,7 @@ const usage = (exitCode = 1): never => {
       '  desktop-plus-cli clone [-b branch] <url>   Clone the repository by url or name/owner\n' +
       '                                             (ex torvalds/linux), optionally checking\n' +
       '                                             out the branch\n' +
+      '\nOptions:\n' +
       '  -n, --new-window                           Open in a new window instead of reusing\n' +
       '                                             an existing one\n'
   )

--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -34,8 +34,8 @@ const run = (...args: Array<string>) => {
 }
 
 const args = parse(process.argv.slice(2), {
-  alias: { help: 'h', branch: 'b' },
-  boolean: ['help'],
+  alias: { help: 'h', branch: 'b', 'new-window': 'n' },
+  boolean: ['help', 'new-window'],
 })
 
 const usage = (exitCode = 1): never => {
@@ -45,12 +45,16 @@ const usage = (exitCode = 1): never => {
       '  desktop-plus-cli open [path]               Open the provided path\n' +
       '  desktop-plus-cli clone [-b branch] <url>   Clone the repository by url or name/owner\n' +
       '                                             (ex torvalds/linux), optionally checking\n' +
-      '                                             out the branch\n'
+      '                                             out the branch\n' +
+      '  -n, --new-window                           Open in a new window instead of reusing\n' +
+      '                                             an existing one\n'
   )
   process.exit(exitCode)
 }
 
 delete process.env.ELECTRON_RUN_AS_NODE
+
+const newWindowArgs = args['new-window'] ? ['--cli-new-window'] : []
 
 if (args.help || args._.at(0) === 'help') {
   usage(0)
@@ -65,13 +69,13 @@ if (args.help || args._.at(0) === 'help') {
   if (!url) {
     usage(1)
   } else if (typeof args.branch === 'string') {
-    run(`--cli-clone=${url}`, `--cli-branch=${args.branch}`)
+    run(`--cli-clone=${url}`, `--cli-branch=${args.branch}`, ...newWindowArgs)
   } else {
-    run(`--cli-clone=${url}`)
+    run(`--cli-clone=${url}`, ...newWindowArgs)
   }
 } else {
   const [firstArg, secondArg] = args._
   const pathArg = firstArg === 'open' ? secondArg : firstArg
   const path = resolve(pathArg ?? '.')
-  run(`--cli-open=${path}`)
+  run(`--cli-open=${path}`, ...newWindowArgs)
 }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -362,7 +362,7 @@ if (__DARWIN__) {
 
 async function handleCommandLineArguments(argv: string[]): Promise<boolean> {
   const args = parseCommandLineArgs(argv, {
-    boolean: ['protocol-launcher'],
+    boolean: ['protocol-launcher', 'cli-new-window'],
   })
 
   // Desktop registers it's protocol handler callback on Windows as
@@ -405,30 +405,53 @@ async function handleCommandLineArguments(argv: string[]): Promise<boolean> {
     // risk a smuggled cli switch
   }
 
+  const forceNewWindow = args['cli-new-window'] === true
+
   if (typeof args['cli-open'] === 'string') {
-    handleCLIAction({ kind: 'open-repository', path: args['cli-open'] })
+    handleCLIAction(
+      { kind: 'open-repository', path: args['cli-open'] },
+      forceNewWindow
+    )
     return true
   } else if (typeof args['cli-clone'] === 'string') {
-    handleCLIAction({
-      kind: 'clone-url',
-      url: args['cli-clone'],
-      branch:
-        typeof args['cli-branch'] === 'string' ? args['cli-branch'] : undefined,
-    })
+    handleCLIAction(
+      {
+        kind: 'clone-url',
+        url: args['cli-clone'],
+        branch:
+          typeof args['cli-branch'] === 'string'
+            ? args['cli-branch']
+            : undefined,
+      },
+      forceNewWindow
+    )
     return true
   }
 
   return false
 }
 
-function handleCLIAction(action: CLIAction) {
-  if (action.kind === 'open-repository') {
+function handleCLIAction(action: CLIAction, forceNewWindow = false) {
+  if (!forceNewWindow && action.kind === 'open-repository') {
     const existingWindow = findWindowForRepositoryPath(action.path)
     if (existingWindow !== null) {
       existingWindow.revealAndFocus()
       existingWindow.sendCLIAction(action)
       return
     }
+  }
+
+  // If we already have at least one window open, honor the request to open
+  // the action in a brand new window rather than reusing an existing one.
+  // If no windows exist yet (e.g. on initial launch) the window created by
+  // the app's normal startup path is already a new window, so we fall
+  // through to `onDidLoad` to avoid spawning a redundant second window.
+  if (forceNewWindow && getAppWindows().length > 0) {
+    createWindow(window => {
+      window.focus()
+      window.sendCLIAction(action)
+    })
+    return
   }
 
   onDidLoad(window => {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -446,7 +446,7 @@ function handleCLIAction(action: CLIAction, forceNewWindow = false) {
   // If no windows exist yet (e.g. on initial launch) the window created by
   // the app's normal startup path is already a new window, so we fall
   // through to `onDidLoad` to avoid spawning a redundant second window.
-  if (forceNewWindow && getAppWindows().length > 0) {
+  if (forceNewWindow && (app.isReady() || getAppWindows().length > 0)) {
     createWindow(window => {
       window.focus()
       window.sendCLIAction(action)

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -432,26 +432,25 @@ async function handleCommandLineArguments(argv: string[]): Promise<boolean> {
 }
 
 function handleCLIAction(action: CLIAction, forceNewWindow = false) {
-  if (!forceNewWindow && action.kind === 'open-repository') {
+  // Before the app is ready we can't create windows, but we don't need to
+  // either: the window created by the app's normal startup path picks the
+  // action up from the pending queue, so creating another one here would just
+  // leave a redundant blank window behind.
+  if (forceNewWindow && app.isReady()) {
+    createWindow(window => {
+      window.focus()
+      window.sendCLIAction(action)
+    })
+    return
+  }
+
+  if (action.kind === 'open-repository') {
     const existingWindow = findWindowForRepositoryPath(action.path)
     if (existingWindow !== null) {
       existingWindow.revealAndFocus()
       existingWindow.sendCLIAction(action)
       return
     }
-  }
-
-  // If we already have at least one window open, honor the request to open
-  // the action in a brand new window rather than reusing an existing one.
-  // If no windows exist yet (e.g. on initial launch) the window created by
-  // the app's normal startup path is already a new window, so we fall
-  // through to `onDidLoad` to avoid spawning a redundant second window.
-  if (forceNewWindow && (app.isReady() || getAppWindows().length > 0)) {
-    createWindow(window => {
-      window.focus()
-      window.sendCLIAction(action)
-    })
-    return
   }
 
   onDidLoad(window => {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,7 +10,12 @@ desktop-plus-cli open [path]               Open the provided path
 desktop-plus-cli clone [-b branch] <url>   Clone a repository by URL or name/owner (e.g. torvalds/linux)
 ```
 
-Add `-n`/`--new-window` to any of the commands above to always open the result in a new window instead of reusing an existing one, e.g. `desktop-plus-cli open --new-window [path]`.
+### Options
+
+- Add `-n`/`--new-window` to any of the commands above to always open the result in a new window instead of reusing an existing one.  
+  ```bash
+  desktop-plus-cli open --new-window [path]
+  ```
 
 ## Creating a shorter alias
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,8 @@ desktop-plus-cli open [path]               Open the provided path
 desktop-plus-cli clone [-b branch] <url>   Clone a repository by URL or name/owner (e.g. torvalds/linux)
 ```
 
+Add `-n`/`--new-window` to any of the commands above to always open the result in a new window instead of reusing an existing one, e.g. `desktop-plus-cli open --new-window [path]`.
+
 ## Creating a shorter alias
 
 If you find `desktop-plus-cli` too long to type, you can create a shorter alias in your shell (e.g. `github-plus`, or even just `github` to match the upstream CLI name).


### PR DESCRIPTION
Fixes #242 

This pull request adds support for a new `--new-window` (`-n`) flag to the CLI, allowing users to open repositories or clone results in a new window instead of reusing an existing one. The implementation updates both the CLI argument parsing and the main process handling logic, and updates documentation to reflect the new option.

**CLI Enhancements:**

* Added support for the `--new-window` (`-n`) flag in the CLI, allowing users to open repositories or clone targets in a new window instead of reusing an existing one (`app/src/cli/main.ts`). [[1]](diffhunk://#diff-507b805ab514ce19e42119dd6cc9509e651ffce3532ffa27be70c9118c4a529bL37-R38) [[2]](diffhunk://#diff-507b805ab514ce19e42119dd6cc9509e651ffce3532ffa27be70c9118c4a529bL48-R58) [[3]](diffhunk://#diff-507b805ab514ce19e42119dd6cc9509e651ffce3532ffa27be70c9118c4a529bL68-R80)

**Main Process Updates:**

* Updated the main process to recognize the `--cli-new-window` argument and to honor requests to always open actions in a new window, unless no windows exist yet (`app/src/main-process/main.ts`). [[1]](diffhunk://#diff-3c15cd9fd36749a6e981aff20fb95658f8169ae5a2225f81f5f87fa4caa88a74L365-R365) [[2]](diffhunk://#diff-3c15cd9fd36749a6e981aff20fb95658f8169ae5a2225f81f5f87fa4caa88a74R408-R435) [[3]](diffhunk://#diff-3c15cd9fd36749a6e981aff20fb95658f8169ae5a2225f81f5f87fa4caa88a74R444-R456)

**Documentation:**

* Updated CLI documentation to describe the new `-n`/`--new-window` flag and provide usage examples (`docs/cli.md`).

> [!IMPORTANT]
> This was vibe-coded entirely via a GitHub/Copilot agent. I don't know how to run a dev version of the CLI locally so this is untested.