### PR TITLE
Add a selectable Catppuccin diff color theme

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -58,6 +58,7 @@ import { ShowBranchNameInRepoListSetting } from '../models/show-branch-name-in-r
 import { CopyPathNormalization } from '../models/copy-path-normalization'
 import { BranchSortOrder } from '../models/branch-sort-order'
 import { DiffFontFamily } from '../models/diff-font'
+import { DiffTheme } from '../models/diff-theme'
 import { DragElement } from '../models/drag-drop'
 import { ILastThankYou } from '../models/last-thank-you'
 import {
@@ -343,6 +344,9 @@ export interface IAppState {
 
   /** The selected font family preference for text diffs */
   readonly selectedDiffFontFamily: DiffFontFamily
+
+  /** The selected color theme for text diffs */
+  readonly selectedDiffTheme: DiffTheme
 
   /** The selected title bar style for the application */
   readonly titleBarStyle: TitleBarStyle

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -22,6 +22,11 @@ import {
   defaultDiffFontFamily,
   DiffFontFamily,
 } from '../../models/diff-font'
+import {
+  defaultDiffTheme,
+  DiffTheme,
+  parseDiffTheme,
+} from '../../models/diff-theme'
 import { EditorOverride } from '../../models/editor-override'
 import { stageResolvedConflictFiles } from '../git/stage'
 import {
@@ -579,6 +584,7 @@ export const tabSizeDefault: number = 4
 const tabSizeKey: string = 'tab-size'
 const diffFontSizeKey = 'diff-font-size'
 const diffFontFamilyKey = 'diff-font-family'
+const diffThemeKey = 'diff-theme'
 
 const shellKey = 'shell'
 
@@ -776,6 +782,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedTabSize = tabSizeDefault
   private selectedDiffFontSize = defaultDiffFontSize
   private selectedDiffFontFamily = defaultDiffFontFamily
+  private selectedDiffTheme = defaultDiffTheme
   private titleBarStyle: TitleBarStyle = __WIN32__ ? 'custom' : 'native'
   private showRecentRepositories: boolean = true
   private showWorktrees: boolean = false
@@ -1476,6 +1483,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedTabSize: this.selectedTabSize,
       selectedDiffFontSize: this.selectedDiffFontSize,
       selectedDiffFontFamily: this.selectedDiffFontFamily,
+      selectedDiffTheme: this.selectedDiffTheme,
       titleBarStyle: this.titleBarStyle,
       showRecentRepositories: this.showRecentRepositories,
       showWorktrees: this.showWorktrees,
@@ -3118,6 +3126,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.selectedDiffFontSize = getNumber(diffFontSizeKey, defaultDiffFontSize)
     this.selectedDiffFontFamily =
       localStorage.getItem(diffFontFamilyKey) || defaultDiffFontFamily
+    this.selectedDiffTheme = parseDiffTheme(localStorage.getItem(diffThemeKey))
 
     themeChangeMonitor.onThemeChanged(theme => {
       this.currentTheme = theme
@@ -10234,6 +10243,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.selectedDiffFontFamily = diffFontFamily
     localStorage.setItem(diffFontFamilyKey, diffFontFamily)
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide diff color theme
+   */
+  public _setSelectedDiffTheme(diffTheme: DiffTheme) {
+    if (this.selectedDiffTheme === diffTheme) {
+      return Promise.resolve()
+    }
+
+    this.selectedDiffTheme = diffTheme
+    localStorage.setItem(diffThemeKey, diffTheme)
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/models/diff-theme.ts
+++ b/app/src/models/diff-theme.ts
@@ -1,0 +1,24 @@
+export type DiffTheme = 'default' | 'catppuccin'
+
+export const defaultDiffTheme: DiffTheme = 'default'
+export const catppuccinDiffTheme: DiffTheme = 'catppuccin'
+
+export const availableDiffThemes: ReadonlyArray<DiffTheme> = [
+  defaultDiffTheme,
+  catppuccinDiffTheme,
+]
+
+const diffThemeLabels: Readonly<Record<DiffTheme, string>> = {
+  default: 'Default',
+  catppuccin: 'Catppuccin (matches app theme)',
+}
+
+export function parseDiffTheme(value: string | null): DiffTheme {
+  return availableDiffThemes.includes(value as DiffTheme)
+    ? (value as DiffTheme)
+    : defaultDiffTheme
+}
+
+export function getDiffThemeLabel(theme: DiffTheme): string {
+  return diffThemeLabels[theme]
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -36,6 +36,7 @@ import {
   getDiffFontFamilyCssValue,
   getDiffLineHeight,
 } from '../models/diff-font'
+import { catppuccinDiffTheme } from '../models/diff-theme'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
 import { Account, isDotComAccount } from '../models/account'
@@ -1967,6 +1968,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedTabSize={this.state.selectedTabSize}
             selectedDiffFontSize={this.state.selectedDiffFontSize}
             selectedDiffFontFamily={this.state.selectedDiffFontFamily}
+            selectedDiffTheme={this.state.selectedDiffTheme}
             useCustomEditor={this.state.useCustomEditor}
             customEditor={this.state.customEditor}
             useCustomShell={this.state.useCustomShell}
@@ -4471,6 +4473,8 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.state.appIsFocused ? 'focused' : 'blurred',
       {
         'underline-links': this.state.underlineLinks,
+        'diff-theme-catppuccin':
+          this.state.selectedDiffTheme === catppuccinDiffTheme,
       }
     )
 

--- a/app/src/ui/diff/diff-minimap.tsx
+++ b/app/src/ui/diff/diff-minimap.tsx
@@ -265,11 +265,19 @@ export class DiffMinimap extends React.PureComponent<IDiffMinimapProps> {
     }
 
     this.lastThemeClassName = this.getThemeClassName()
-    this.themeObserver = new MutationObserver(this.onBodyClassChanged)
+    this.themeObserver = new MutationObserver(this.onThemeClassChanged)
     this.themeObserver.observe(document.body, {
       attributes: true,
       attributeFilter: ['class'],
     })
+
+    const appChrome = document.getElementById('desktop-app-chrome')
+    if (appChrome !== null) {
+      this.themeObserver.observe(appChrome, {
+        attributes: true,
+        attributeFilter: ['class'],
+      })
+    }
   }
 
   private disconnectResizeObserver() {
@@ -302,7 +310,7 @@ export class DiffMinimap extends React.PureComponent<IDiffMinimapProps> {
     }
   }
 
-  private onBodyClassChanged = () => {
+  private onThemeClassChanged = () => {
     const nextThemeClassName = this.getThemeClassName()
     if (nextThemeClassName === this.lastThemeClassName) {
       return
@@ -314,10 +322,15 @@ export class DiffMinimap extends React.PureComponent<IDiffMinimapProps> {
   }
 
   private getThemeClassName() {
-    const themeClass = [...document.body.classList].find(c =>
+    const appChrome = document.getElementById('desktop-app-chrome')
+    const applicationTheme = [...document.body.classList].find(c =>
       c.startsWith('theme-')
     )
-    return themeClass ?? ''
+    const diffTheme = [...(appChrome?.classList ?? [])].find(c =>
+      c.startsWith('diff-theme-')
+    )
+
+    return `${applicationTheme ?? ''} ${diffTheme ?? ''}`
   }
 
   private scheduleRedraw() {
@@ -1608,7 +1621,7 @@ export class DiffMinimap extends React.PureComponent<IDiffMinimapProps> {
     const read = (name: string, fallback: string) =>
       styles.getPropertyValue(name).trim() || fallback
     return {
-      background: read('--box-alt-background-color', '#f6f8fa'),
+      background: read('--diff-minimap-background-color', '#f6f8fa'),
       border: read('--diff-border-color', '#d0d7de'),
       context: read('--diff-text-color', '#24292f'),
       added: read('--diff-add-inner-background-color', '#2da44e'),

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -113,6 +113,7 @@ import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-str
 import { BranchSortOrder } from '../../models/branch-sort-order'
 import { ShowBranchNameInRepoListSetting } from '../../models/show-branch-name-in-repo-list'
 import { DiffFontFamily } from '../../models/diff-font'
+import { DiffTheme } from '../../models/diff-theme'
 import { CopyPathNormalization } from '../../models/copy-path-normalization'
 import { IStashEntry } from '../../models/stash-entry'
 import { WorkflowPreferences } from '../../models/workflow-preferences'
@@ -3073,6 +3074,13 @@ export class Dispatcher {
    */
   public setSelectedDiffFontFamily(diffFontFamily: DiffFontFamily) {
     return this.appStore._setSelectedDiffFontFamily(diffFontFamily)
+  }
+
+  /**
+   * Set the application-wide diff color theme
+   */
+  public setSelectedDiffTheme(diffTheme: DiffTheme) {
+    return this.appStore._setSelectedDiffTheme(diffTheme)
   }
   /*
    * Set the title bar style for the application

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -24,6 +24,11 @@ import {
   getAvailableDiffFontFamilies,
   getDiffFontFamilyLabel,
 } from '../../models/diff-font'
+import {
+  availableDiffThemes,
+  DiffTheme,
+  getDiffThemeLabel,
+} from '../../models/diff-theme'
 import { enableFormattingPreferences } from '../../lib/feature-flag'
 import {
   DateFormat,
@@ -47,6 +52,8 @@ interface IAppearanceProps {
   readonly onSelectedDiffFontFamilyChanged: (
     diffFontFamily: DiffFontFamily
   ) => void
+  readonly selectedDiffTheme: DiffTheme
+  readonly onSelectedDiffThemeChanged: (diffTheme: DiffTheme) => void
   readonly titleBarStyle: TitleBarStyle
   readonly onTitleBarStyleChanged: (titleBarStyle: TitleBarStyle) => void
   readonly showRecentRepositories: boolean
@@ -80,6 +87,7 @@ interface IAppearanceState {
   readonly selectedTabSize: number
   readonly selectedDiffFontSize: number
   readonly selectedDiffFontFamily: DiffFontFamily
+  readonly selectedDiffTheme: DiffTheme
   readonly availableDiffFontFamilies: ReadonlyArray<DiffFontFamily>
   readonly titleBarStyle: TitleBarStyle
   readonly showRecentRepositories: boolean
@@ -116,6 +124,7 @@ export class Appearance extends React.Component<
       selectedTabSize: props.selectedTabSize,
       selectedDiffFontSize: props.selectedDiffFontSize,
       selectedDiffFontFamily: props.selectedDiffFontFamily,
+      selectedDiffTheme: props.selectedDiffTheme,
       availableDiffFontFamilies:
         props.selectedDiffFontFamily === defaultDiffFontFamily
           ? [defaultDiffFontFamily]
@@ -153,12 +162,14 @@ export class Appearance extends React.Component<
     const selectedTabSize = this.props.selectedTabSize
     const selectedDiffFontSize = this.props.selectedDiffFontSize
     const selectedDiffFontFamily = this.props.selectedDiffFontFamily
+    const selectedDiffTheme = this.props.selectedDiffTheme
 
     this.setState({
       selectedTheme,
       selectedTabSize,
       selectedDiffFontSize,
       selectedDiffFontFamily,
+      selectedDiffTheme,
       showWorktrees: this.props.showWorktrees,
       showWorktreesInRepoList: this.props.showWorktreesInRepoList,
       showCompareTab: this.props.showCompareTab,
@@ -180,6 +191,7 @@ export class Appearance extends React.Component<
       selectedTabSize,
       selectedDiffFontSize: this.props.selectedDiffFontSize,
       selectedDiffFontFamily: this.props.selectedDiffFontFamily,
+      selectedDiffTheme: this.props.selectedDiffTheme,
     })
   }
 
@@ -257,6 +269,15 @@ export class Appearance extends React.Component<
     const value = event.currentTarget.value
     if (value) {
       this.props.onSelectedDiffFontFamilyChanged(value)
+    }
+  }
+
+  private onSelectedDiffThemeChanged = (
+    event: React.FormEvent<HTMLSelectElement>
+  ) => {
+    const diffTheme = event.currentTarget.value as DiffTheme
+    if (availableDiffThemes.includes(diffTheme)) {
+      this.props.onSelectedDiffThemeChanged(diffTheme)
     }
   }
 
@@ -593,6 +614,18 @@ export class Appearance extends React.Component<
     return (
       <div className="advanced-section">
         <h2 id="diff-heading">Diff</h2>
+
+        <Select
+          value={this.state.selectedDiffTheme}
+          label="Color theme"
+          onChange={this.onSelectedDiffThemeChanged}
+        >
+          {availableDiffThemes.map(diffTheme => (
+            <option key={diffTheme} value={diffTheme}>
+              {getDiffThemeLabel(diffTheme)}
+            </option>
+          ))}
+        </Select>
 
         <Select
           value={this.state.selectedDiffFontSize.toString()}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -28,6 +28,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Integrations } from './integrations'
 import { BranchSortOrder } from '../../models/branch-sort-order'
 import { DiffFontFamily } from '../../models/diff-font'
+import { DiffTheme } from '../../models/diff-theme'
 import {
   UncommittedChangesStrategy,
   defaultUncommittedChangesStrategy,
@@ -121,6 +122,7 @@ interface IPreferencesProps {
   readonly selectedTabSize: number
   readonly selectedDiffFontSize: number
   readonly selectedDiffFontFamily: DiffFontFamily
+  readonly selectedDiffTheme: DiffTheme
   readonly useCustomEditor: boolean
   readonly customEditor: ICustomIntegration | null
   readonly useCustomShell: boolean
@@ -206,6 +208,7 @@ interface IPreferencesState {
   readonly initiallySelectedTabSize: number
   readonly initiallySelectedDiffFontSize: number
   readonly initiallySelectedDiffFontFamily: DiffFontFamily
+  readonly initiallySelectedDiffTheme: DiffTheme
 
   readonly isLoadingGitConfig: boolean
 
@@ -298,6 +301,7 @@ export class Preferences extends React.Component<
       initiallySelectedTabSize: this.props.selectedTabSize,
       initiallySelectedDiffFontSize: this.props.selectedDiffFontSize,
       initiallySelectedDiffFontFamily: this.props.selectedDiffFontFamily,
+      initiallySelectedDiffTheme: this.props.selectedDiffTheme,
       isLoadingGitConfig: true,
       underlineLinks: this.props.underlineLinks,
       showDiffCheckMarks: this.props.showDiffCheckMarks,
@@ -440,6 +444,11 @@ export class Preferences extends React.Component<
       this.onSelectedDiffFontFamilyChanged(
         this.state.initiallySelectedDiffFontFamily
       )
+    }
+    if (
+      this.state.initiallySelectedDiffTheme !== this.props.selectedDiffTheme
+    ) {
+      this.onSelectedDiffThemeChanged(this.state.initiallySelectedDiffTheme)
     }
 
     this.props.onDismissed()
@@ -763,6 +772,8 @@ export class Preferences extends React.Component<
             onSelectedDiffFontFamilyChanged={
               this.onSelectedDiffFontFamilyChanged
             }
+            selectedDiffTheme={this.props.selectedDiffTheme}
+            onSelectedDiffThemeChanged={this.onSelectedDiffThemeChanged}
             titleBarStyle={this.props.titleBarStyle}
             onTitleBarStyleChanged={this.onTitleBarStyleChanged}
             showRecentRepositories={this.props.showRecentRepositories}
@@ -1164,6 +1175,10 @@ export class Preferences extends React.Component<
     diffFontFamily: DiffFontFamily
   ) => {
     this.props.dispatcher.setSelectedDiffFontFamily(diffFontFamily)
+  }
+
+  private onSelectedDiffThemeChanged = (diffTheme: DiffTheme) => {
+    this.props.dispatcher.setSelectedDiffTheme(diffTheme)
   }
 
   private onTitleBarStyleChanged = (titleBarStyle: TitleBarStyle) => {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -403,11 +403,13 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --diff-line-padding-y: 2px;
 
+  --diff-background-color: var(--background-color);
   --diff-text-color: #{$gray-900};
   --diff-alt-text-color: #{$gray-700};
   --diff-border-color: #{$gray-200};
   --diff-gutter-color: #{$gray-200};
   --diff-gutter-background-color: var(--background-color);
+  --diff-minimap-background-color: var(--box-alt-background-color);
 
   --diff-line-number-color: #{$gray-700};
   --diff-line-number-column-width: 50px;

--- a/app/styles/desktop.scss
+++ b/app/styles/desktop.scss
@@ -2,6 +2,7 @@
 
 @import 'variables';
 @import 'themes/dark';
+@import 'themes/catppuccin-diff';
 
 @import 'mixins';
 

--- a/app/styles/themes/_catppuccin-diff.scss
+++ b/app/styles/themes/_catppuccin-diff.scss
@@ -1,0 +1,157 @@
+// Catppuccin diff palettes follow the official editor color guidance:
+// https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
+// Add/delete overlays use the same opacity levels as Catppuccin for VS Code.
+
+#desktop-app-chrome.diff-theme-catppuccin {
+  // Latte
+  --diff-background-color: #eff1f5;
+  --diff-text-color: #4c4f69;
+  --diff-alt-text-color: #5c5f77;
+  --diff-border-color: #bcc0cc;
+  --diff-gutter-color: #acb0be;
+  --diff-gutter-background-color: #e6e9ef;
+  --diff-minimap-background-color: #e6e9ef;
+  --diff-line-number-color: #6c6f85;
+
+  --diff-selected-background-color: #1e66f5;
+  --diff-selected-border-color: #1e66f5;
+  --diff-selected-gutter-color: #1e66f5;
+  --diff-selected-text-color: #eff1f5;
+
+  --diff-add-background-color: rgba(64, 160, 43, 0.15);
+  --diff-add-border-color: rgba(64, 160, 43, 0.48);
+  --diff-add-gutter-color: #40a02b;
+  --diff-add-gutter-background-color: rgba(64, 160, 43, 0.2);
+  --diff-add-inner-background-color: rgba(64, 160, 43, 0.3);
+  --diff-add-text-color: var(--diff-text-color);
+
+  --diff-delete-background-color: rgba(210, 15, 57, 0.15);
+  --diff-delete-border-color: rgba(210, 15, 57, 0.48);
+  --diff-delete-gutter-color: #d20f39;
+  --diff-delete-gutter-background-color: rgba(210, 15, 57, 0.2);
+  --diff-delete-inner-background-color: rgba(210, 15, 57, 0.3);
+  --diff-delete-text-color: var(--diff-text-color);
+
+  --diff-hunk-background-color: #e6e9ef;
+  --diff-hunk-border-color: #bcc0cc;
+  --diff-hunk-gutter-color: #acb0be;
+  --diff-hunk-gutter-background-color: #dce0e8;
+  --diff-hunk-text-color: #5c5f77;
+
+  --diff-hover-background-color: rgba(30, 102, 245, 0.24);
+  --diff-hover-border-color: #1e66f5;
+  --diff-hover-gutter-color: #1e66f5;
+  --diff-hover-text-color: var(--diff-text-color);
+
+  --diff-add-hover-background-color: rgba(64, 160, 43, 0.28);
+  --diff-add-hover-border-color: #40a02b;
+  --diff-add-hover-gutter-color: #40a02b;
+  --diff-add-hover-text-color: var(--diff-text-color);
+
+  --diff-delete-hover-background-color: rgba(210, 15, 57, 0.28);
+  --diff-delete-hover-border-color: #d20f39;
+  --diff-delete-hover-gutter-color: #d20f39;
+  --diff-delete-hover-text-color: var(--diff-text-color);
+
+  --diff-empty-row-background-color: #e6e9ef;
+  --diff-empty-row-gutter-background-color: #e6e9ef;
+  --diff-empty-hunk-handle: #acb0be;
+
+  --syntax-variable-color: #4c4f69;
+  --syntax-alt-variable-color: #e64553;
+  --syntax-keyword-color: #8839ef;
+  --syntax-atom-color: #fe640b;
+  --syntax-number-color: #fe640b;
+  --syntax-definition-color: #1e66f5;
+  --syntax-string-color: #40a02b;
+  --syntax-qualifier-color: #df8e1d;
+  --syntax-type-color: #df8e1d;
+  --syntax-comment-color: #7c7f93;
+  --syntax-meta-color: #df8e1d;
+  --syntax-tag-color: #179299;
+  --syntax-attribute-color: #df8e1d;
+  --syntax-link-color: #1e66f5;
+  --syntax-header-color: #8839ef;
+  --syntax-quote-color: #40a02b;
+  --syntax-builtin-color: #d20f39;
+  --syntax-bracket-color: #7c7f93;
+  --syntax-operator-color: #04a5e5;
+  --syntax-property-color: #1e66f5;
+}
+
+body.theme-dark #desktop-app-chrome.diff-theme-catppuccin {
+  // Mocha
+  --diff-background-color: #1e1e2e;
+  --diff-text-color: #cdd6f4;
+  --diff-alt-text-color: #bac2de;
+  --diff-border-color: #45475a;
+  --diff-gutter-color: #313244;
+  --diff-gutter-background-color: #181825;
+  --diff-minimap-background-color: #181825;
+  --diff-line-number-color: #7f849c;
+
+  --diff-selected-background-color: rgba(137, 180, 250, 0.35);
+  --diff-selected-border-color: #89b4fa;
+  --diff-selected-gutter-color: #89b4fa;
+  --diff-selected-text-color: #cdd6f4;
+
+  --diff-add-background-color: rgba(166, 227, 161, 0.15);
+  --diff-add-border-color: rgba(166, 227, 161, 0.48);
+  --diff-add-gutter-color: #a6e3a1;
+  --diff-add-gutter-background-color: rgba(166, 227, 161, 0.2);
+  --diff-add-inner-background-color: rgba(166, 227, 161, 0.3);
+  --diff-add-text-color: var(--diff-text-color);
+
+  --diff-delete-background-color: rgba(243, 139, 168, 0.15);
+  --diff-delete-border-color: rgba(243, 139, 168, 0.48);
+  --diff-delete-gutter-color: #f38ba8;
+  --diff-delete-gutter-background-color: rgba(243, 139, 168, 0.2);
+  --diff-delete-inner-background-color: rgba(243, 139, 168, 0.3);
+  --diff-delete-text-color: var(--diff-text-color);
+
+  --diff-hunk-background-color: #181825;
+  --diff-hunk-border-color: #313244;
+  --diff-hunk-gutter-color: #45475a;
+  --diff-hunk-gutter-background-color: #11111b;
+  --diff-hunk-text-color: #a6adc8;
+
+  --diff-hover-background-color: rgba(137, 180, 250, 0.25);
+  --diff-hover-border-color: #89b4fa;
+  --diff-hover-gutter-color: #89b4fa;
+  --diff-hover-text-color: var(--diff-text-color);
+
+  --diff-add-hover-background-color: rgba(166, 227, 161, 0.28);
+  --diff-add-hover-border-color: #a6e3a1;
+  --diff-add-hover-gutter-color: #a6e3a1;
+  --diff-add-hover-text-color: var(--diff-text-color);
+
+  --diff-delete-hover-background-color: rgba(243, 139, 168, 0.28);
+  --diff-delete-hover-border-color: #f38ba8;
+  --diff-delete-hover-gutter-color: #f38ba8;
+  --diff-delete-hover-text-color: var(--diff-text-color);
+
+  --diff-empty-row-background-color: #181825;
+  --diff-empty-row-gutter-background-color: #181825;
+  --diff-empty-hunk-handle: #45475a;
+
+  --syntax-variable-color: #cdd6f4;
+  --syntax-alt-variable-color: #eba0ac;
+  --syntax-keyword-color: #cba6f7;
+  --syntax-atom-color: #fab387;
+  --syntax-number-color: #fab387;
+  --syntax-definition-color: #89b4fa;
+  --syntax-string-color: #a6e3a1;
+  --syntax-qualifier-color: #f9e2af;
+  --syntax-type-color: #f9e2af;
+  --syntax-comment-color: #9399b2;
+  --syntax-meta-color: #f9e2af;
+  --syntax-tag-color: #94e2d5;
+  --syntax-attribute-color: #f9e2af;
+  --syntax-link-color: #89b4fa;
+  --syntax-header-color: #cba6f7;
+  --syntax-quote-color: #a6e3a1;
+  --syntax-builtin-color: #f38ba8;
+  --syntax-bracket-color: #9399b2;
+  --syntax-operator-color: #89dceb;
+  --syntax-property-color: #89b4fa;
+}

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -301,11 +301,13 @@ body.theme-dark {
    * Diff view
    */
 
+  --diff-background-color: var(--background-color);
   --diff-text-color: var(--text-color);
   --diff-alt-text-color: #{darken($gray-100, 20%)};
   --diff-border-color: #{$gray-800};
   --diff-gutter-color: #{$gray-800};
   --diff-gutter-background-color: #{darken($gray-900, 3%)};
+  --diff-minimap-background-color: var(--box-alt-background-color);
 
   --diff-line-number-color: var(--text-secondary-color);
   --diff-line-number-column-width: 50px;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -10,7 +10,7 @@
 .diff-code-mirror .CodeMirror {
   height: 100%;
   color: var(--diff-text-color);
-  background: var(--background-color);
+  background: var(--diff-background-color);
   font-size: var(--diff-font-size, var(--font-size-sm));
   font-family: var(--diff-font-family, var(--font-family-monospace));
 
@@ -287,7 +287,7 @@
   }
 
   &.diff-context {
-    background: var(--background-color);
+    background: var(--diff-background-color);
   }
 
   &.diff-hunk {
@@ -699,11 +699,11 @@
     color: var(--syntax-atom-color);
   }
   .cm-number {
-    color: inherit;
+    color: var(--syntax-number-color, inherit);
   }
 
   .cm-def {
-    color: inherit;
+    color: var(--syntax-definition-color, inherit);
   }
 
   .cm-quote {
@@ -714,16 +714,18 @@
   .cm-variable-3 {
     color: var(--syntax-alt-variable-color);
   }
-  .cm-comment,
-  .cm-meta {
+  .cm-comment {
     color: var(--syntax-comment-color);
+  }
+  .cm-meta {
+    color: var(--syntax-meta-color, var(--syntax-comment-color));
   }
   .cm-string,
   .cm-string-2 {
     color: var(--syntax-string-color);
 
     &.cm-property {
-      color: inherit;
+      color: var(--syntax-property-color, inherit);
     }
   }
   .cm-qualifier {
@@ -733,10 +735,16 @@
     color: var(--syntax-type-color);
   }
   .cm-builtin {
-    color: inherit;
+    color: var(--syntax-builtin-color, inherit);
   }
   .cm-bracket {
-    color: inherit;
+    color: var(--syntax-bracket-color, inherit);
+  }
+  .cm-operator {
+    color: var(--syntax-operator-color, inherit);
+  }
+  .cm-property {
+    color: var(--syntax-property-color, inherit);
   }
   .cm-tag {
     color: var(--syntax-tag-color);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -132,7 +132,7 @@
     padding: 0;
     border: 0;
     border-left: 1px solid var(--diff-border-color);
-    background: var(--box-alt-background-color);
+    background: var(--diff-minimap-background-color);
     appearance: none;
     overflow: hidden;
 

--- a/app/test/unit/diff-theme-test.ts
+++ b/app/test/unit/diff-theme-test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import {
+  catppuccinDiffTheme,
+  defaultDiffTheme,
+  getDiffThemeLabel,
+  parseDiffTheme,
+} from '../../src/models/diff-theme'
+
+describe('diff theme', () => {
+  it('parses supported persisted themes', () => {
+    assert.strictEqual(parseDiffTheme('default'), defaultDiffTheme)
+    assert.strictEqual(parseDiffTheme('catppuccin'), catppuccinDiffTheme)
+  })
+
+  it('falls back to the default for missing and unknown values', () => {
+    assert.strictEqual(parseDiffTheme(null), defaultDiffTheme)
+    assert.strictEqual(parseDiffTheme('unknown'), defaultDiffTheme)
+  })
+
+  it('describes the adaptive Catppuccin palette', () => {
+    assert.strictEqual(
+      getDiffThemeLabel(catppuccinDiffTheme),
+      'Catppuccin (matches app theme)'
+    )
+  })
+})


### PR DESCRIPTION
Closes #249

## Description

- Add a persisted **Color theme** setting under **Options → Appearance → Diff**.
- Keep the existing diff colors as the default and add an opt-in Catppuccin theme that follows the application's light/dark mode (Latte/Mocha).
- Theme diff rows, line numbers, selection/focus states, the minimap, and syntax tokens without changing the rest of the application theme.
- Keep the palette in CSS custom properties so future diff themes can use the same path without adding rendering logic.

### Screenshots

![Catppuccin Mocha diff theme on a Laravel/PHP diff](https://github.com/cyppe/desktop-plus/releases/download/custom-v3.6.5-beta1-r1/desktop-plus-custom-catppuccin-cm6-laravel.png)

The screenshot is from the combined local verification build. The color behavior shown here is this PR; the independent CodeMirror 6 highlighting change is in #252.

## Test plan

- [x] `yarn test:unit app/test/unit/diff-theme-test.ts`
- [x] `yarn build:prod`
- [x] Verified the production-packaged Linux AppImage in unified and side-by-side diffs, including the minimap and light/dark application themes.

## Release notes

Notes: [Added] Add a selectable Catppuccin diff color theme.
